### PR TITLE
Update ktrim.py

### DIFF
--- a/ktrim.py
+++ b/ktrim.py
@@ -400,9 +400,9 @@ def identify_adapters(artificial_artifacts, forward = "", reverse = "", unpaired
 		u_check = True
 		count += 1
 	
-	fastqc_command_f = ["fastqc", "--quiet", "-o", output, forward]
-	fastqc_command_r = ["fastqc", "--quiet", "-o", output, reverse]
-	fastqc_command_u = ["fastqc", "--quiet", "-o", output, unpaired]
+	fastqc_command_f = ["falco", "--quiet", "-o", output, forward]
+	fastqc_command_r = ["falco", "--quiet", "-o", output, reverse]
+	fastqc_command_u = ["falco", "--quiet", "-o", output, unpaired]
 	
 	seqtk_command_f = ["seqtk", "sample", "-s", "100", forward, "100000"]
 	seqtk_command_r = ["seqtk", "sample", "-s", "100", reverse, "100000"]


### PR DESCRIPTION
using falco instead of fastQC for final quality check (an C++ alternative). falco can be installed via conda or compiled from source on both linux and MacOS. Exact the same syntax with fastQC